### PR TITLE
Better workflow concurrency

### DIFF
--- a/aquatx/aquatx.py
+++ b/aquatx/aquatx.py
@@ -21,8 +21,9 @@ the keys ` samples_csv` and `reference_sheet_file` (use get-template for
 more info). Config files that share the same name as the template config file
 will be renamed.
 """
-
+import cwltool.executors
 import cwltool.factory
+import cwltool.secrets
 import subprocess
 import shutil
 import os
@@ -79,21 +80,60 @@ def run(aquatx_cwl_path: str, config_file: str) -> None:
     run_directory = config_object.create_run_directory()
     cwl_conf_file = config_object.write_processed_config()
 
-    # Run with cwltool
     debug = False
-    subprocess.run(f"cwltool --outdir {run_directory} --copy-outputs --timestamps "
-                   f"{'--leave-tmpdir --debug --js-console ' if debug else ''}"
-                   f"{aquatx_cwl_path}/workflows/aquatx_wf.cwl {cwl_conf_file}", shell=True)
+    if config_object['run_native']:  # experimental
+        run_native(config_object, aquatx_cwl_path, run_directory,
+                   debug=debug, parallel=config_object['run_parallel'])
+    else:
+        if config_object['run_parallel']:
+            # Use the toil CWL runner for parallel library processing
+            cwl_runner = f"toil-cwl-runner --outdir {run_directory} --stats " \
+                         f"{f'--debug-Worker --writeLogs {run_directory}' if debug else ''}" \
+                         f"{aquatx_cwl_path}/workflows/aquatx_wf.cwl {cwl_conf_file}"
+        else:
+            # Use the cwltool CWL runner to run one library at a time
+            cwl_runner = f"cwltool --outdir {run_directory} --copy-outputs --timestamps " \
+                         f"{'--leave-tmpdir --debug --js-console ' if debug else ''}" \
+                         f"{aquatx_cwl_path}/workflows/aquatx_wf.cwl {cwl_conf_file}"
 
-    # runtime_context = cwltool.factory.RuntimeContext()
-    # runtime_context.outdir = os.path.join('.', config.get('run_directory'))
-    # runtime_context.on_error = "continue"
-    #
-    # loading_context = cwltool.factory.LoadingContext()
-    # loading_context.jobdefaults = config.config
-    #
-    # cwl = cwltool.factory.Factory(runtime_context=runtime_context, loading_context=loading_context)
-    # cwl.make(f"{aquatx_cwl_path}/workflows/aquatx_wf.cwl")
+        subprocess.run(cwl_runner, shell=True)
+
+
+def run_native(config_object, cwl_path, run_directory, debug=False, parallel=False):
+    def furnish_if_file_record(file_dict):
+        if isinstance(file_dict, dict) and file_dict.get('class', None) == 'File':
+            file_dict['basename'] = os.path.basename(file_dict['path'])
+            file_dict['location'] = file_dict['path']
+            file_dict['contents'] = None
+
+    for _, config_param in config_object.config.items():
+        if isinstance(config_param, list):
+            for config_dict in config_param:
+                furnish_if_file_record(config_dict)
+        else:
+            furnish_if_file_record(config_param)
+
+    runtime_config = {
+        'secret_store': cwltool.secrets.SecretStore(),
+        'outdir': os.path.join('.', run_directory),
+        'default_stdout': subprocess.PIPE,
+        'default_stderr': subprocess.PIPE,
+        'on_error': "continue",
+        'debug': debug
+    }
+
+    runtime_context = cwltool.factory.RuntimeContext()
+    for opt, val in runtime_config.items():
+        setattr(runtime_context, opt, val)
+
+    cwl = cwltool.factory.Factory(
+        runtime_context=runtime_context,
+        executor=cwltool.executors.MultithreadedJobExecutor()   # Run jobs in parallel
+        if parallel else cwltool.executors.SingleJobExecutor()  # Run one library at a time
+    )
+
+    pipeline = cwl.make(f"{cwl_path}/workflows/aquatx_wf.cwl")
+    pipeline(**config_object.config)
 
 
 def get_template(aquatx_extras_path: str) -> None:

--- a/aquatx/aquatx.py
+++ b/aquatx/aquatx.py
@@ -29,8 +29,9 @@ import shutil
 import os
 
 from pkg_resources import resource_filename
-from aquatx.srna.Configuration import Configuration
 from argparse import ArgumentParser
+
+from aquatx.srna.Configuration import Configuration
 
 
 def get_args():
@@ -86,10 +87,12 @@ def run(aquatx_cwl_path: str, config_file: str) -> None:
                    debug=debug, parallel=config_object['run_parallel'])
     else:
         if config_object['run_parallel']:
-            # Use the toil CWL runner for parallel library processing
-            cwl_runner = f"toil-cwl-runner --outdir {run_directory} --stats " \
-                         f"{f'--debug-Worker --writeLogs {run_directory}' if debug else ''}" \
-                         f"{aquatx_cwl_path}/workflows/aquatx_wf.cwl {cwl_conf_file}"
+            print("The Toil CWL runner is not supported at this time. You may run_parallel only with run_native.")
+            return
+            # Use the Toil CWL runner for parallel library processing
+            # cwl_runner = f"toil-cwl-runner --outdir {run_directory} --stats " \
+            #              f"{f'--debug-Worker --writeLogs {run_directory}' if debug else ''}" \
+            #              f"{aquatx_cwl_path}/workflows/aquatx_wf.cwl {cwl_conf_file}"
         else:
             # Use the cwltool CWL runner to run one library at a time
             cwl_runner = f"cwltool --outdir {run_directory} --copy-outputs --timestamps " \

--- a/aquatx/cwl/workflows/per-library.cwl
+++ b/aquatx/cwl/workflows/per-library.cwl
@@ -1,0 +1,146 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  # multi input
+  threads: int?
+
+  # fastp inputs
+  in_fq: File # unscatter
+  out_fq: string  # unscatter
+  fp_phred64: boolean?
+  compression: int?
+  dont_overwrite: boolean?
+  disable_adapter_trimming: boolean?
+  adapter_sequence: string?
+  trim_poly_x: boolean?
+  poly_x_min_len: int?
+  disable_quality_filtering: boolean?
+  qualified_quality_phred: int?
+  unqualified_percent_limit: int?
+  n_base_limit: int?
+  disable_length_filtering: boolean?
+  length_required: int?
+  length_limit: int?
+  overrepresentation_analysis: boolean?
+  overrepresentation_sampling: int?
+  json: string # unscatter
+  html: string # unscatter
+  report_title: string # unscatter
+
+  # collapser inputs
+  uniq_seq_prefix: string # unscatter
+  threshold: int?
+  compress: boolean?
+
+  # bowtie inputs
+  bt_index_files: File[]
+  ebwt: string
+  outfile: string # unscatter
+  fastq: boolean?
+  fasta: boolean?
+  trim5: int?
+  trim3: int?
+  bt_phred64: boolean?
+  solexa: boolean?
+  solexa13: boolean?
+  end_to_end: int?
+  nofw: boolean?
+  norc: boolean?
+  k_aln: int?
+  all_aln: boolean?
+  no_unal: boolean?
+  un: string # unscatter
+  sam: boolean?
+  seed: int?
+  shared_memory: boolean?
+
+steps:
+  fastp:
+    run: ../tools/fastp.cwl
+    in:
+      thread: threads
+      in1: in_fq
+      out1: out_fq
+      phred64: fp_phred64
+      compression: compression
+      dont_overwrite: dont_overwrite
+      disable_adapter_trimming: disable_adapter_trimming
+      adapter_sequence: adapter_sequence
+      trim_poly_x: trim_poly_x
+      poly_x_min_len: poly_x_min_len
+      disable_quality_filtering: disable_quality_filtering
+      qualified_quality_phred: qualified_quality_phred
+      unqualified_percent_limit: unqualified_percent_limit
+      n_base_limit: n_base_limit
+      disable_length_filtering: disable_length_filtering
+      length_required: length_required
+      length_limit: length_limit
+      overrepresentation_analysis: overrepresentation_analysis
+      overrepresentation_sampling: overrepresentation_sampling
+      json: json
+      html: html
+      report_title: report_title
+    out: [fastq1, report_json, report_html]
+
+  collapse:
+    run: ../tools/aquatx-collapse.cwl
+    in:
+      input_file: fastp/fastq1
+      out_prefix: uniq_seq_prefix
+      threshold: threshold
+      compress: compress
+    out: [collapsed_fa, low_counts_fa]
+
+  bowtie:
+    run: ../tools/bowtie.cwl
+    in:
+      bt_index_files: bt_index_files
+      ebwt: ebwt
+      reads: collapse/collapsed_fa
+      outfile: outfile
+      fastq: fastq
+      fasta: fasta
+      trim5: trim5
+      trim3: trim3
+      phred64: bt_phred64
+      solexa: solexa
+      solexa13: solexa13
+      end_to_end: end_to_end
+      nofw: nofw
+      k_aln: k_aln
+      all_aln: all_aln
+      no_unal: no_unal
+      un: un
+      sam: sam
+      threads: threads
+      shared_memory: shared_memory
+      seed: seed
+    out: [sam_out, unal_seqs]
+outputs:
+  fastq_clean:
+    type: File # unscatter
+    outputSource: fastp/fastq1
+
+  html_report_file:
+    type: File # unscatter
+    outputSource: fastp/report_html
+
+  json_report_file:
+    type: File # unscatter
+    outputSource: fastp/report_json
+
+  uniq_seqs:
+    type: File # unscatter
+    outputSource: collapse/collapsed_fa
+
+  aln_seqs:
+    type: File # unscatter
+    outputSource: bowtie/sam_out
+
+  # Optional outputs
+  uniq_seqs_low:
+    type: File? # unscatter
+    outputSource: collapse/low_counts_fa

--- a/aquatx/extras/run_config_template.yml
+++ b/aquatx/extras/run_config_template.yml
@@ -52,6 +52,13 @@ run_idx: False
 ##-- Number of threads for multi-threaded programs --##
 threads: 2
 
+##-- (EXPERIMENTAL) If True: process each sample library in parallel --##
+##-- If run_native is False, the Toil CWL runner will be used --##
+run_parallel: False
+
+##-- (EXPERIMENTAL) If True: execute the pipeline using native cwltool python rather than command line --##
+run_native: False
+
 ##-- Final output file prefixes for overall run --##
 ##-- If none given, run_prefix is used (default: date_time_aquatx) --##
 output_prefix: ~
@@ -168,7 +175,8 @@ fasta: True
 sam: True
 
 ##-- If True: use shared mem for index; many bowtie's can share --##
-shared_memory: True
+##-- Note: this requires further configuration of your OS; see ipcs and ipcrm --#
+shared_memory: False
 
 ###-- Unused option inputs: Remove '#' in front to use --###
 ##-- If true: do not align to reverse-compliment reference --##

--- a/aquatx/srna/counter.py
+++ b/aquatx/srna/counter.py
@@ -194,7 +194,8 @@ def map_and_reduce(libraries, work_args, ret_queue):
     merge_start = time.time()
 
     # Collect counts from all pool workers and merge
-    summary = SummaryStats(libraries, work_args[0][-1])
+    out_prefix = work_args[0][-1]
+    summary = SummaryStats(out_prefix)
     for _ in libraries:
         lib_stats = ret_queue.get()
         summary.add_library(lib_stats)

--- a/environment.yml
+++ b/environment.yml
@@ -8,9 +8,13 @@ dependencies:
   - matplotlib==3.3.2
   - fastp==0.20.1
   - bowtie>=1.2.3
+  - tbb==2020.3  # Bowtie dependency, temporary fix. v2021.x breaks bowtie, is not properly pinned to v2020 in bioconda
   - nodejs>=10.13.0
   - pip
   - pip:
       - htseq
       - psutil
+      - "toil[cwl]"
+      - boto
+      - boto3
       - . # This allows pip to handle the installation of AQuATx via setup.py

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,10 @@ dependencies:
   - pip:
       - htseq
       - psutil
-      - "toil[cwl]"
-      - boto
-      - boto3
+      - cwltool==3.1.20210426140515  # Previous versions fail to find output files with special characters
       - . # This allows pip to handle the installation of AQuATx via setup.py
+
+      # Toil and its dependencies. Current release breaks cwltool.
+      # - "toil[cwl]"
+      # - boto
+      # - boto3

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -52,6 +52,13 @@ run_idx: False
 ##-- Number of threads for multi-threaded programs --##
 threads: 2
 
+##-- (EXPERIMENTAL) If True: process each sample library in parallel --##
+##-- If run_native is False, the Toil CWL runner will be used --##
+run_parallel: False
+
+##-- (EXPERIMENTAL) If True: execute the pipeline using native cwltool python rather than command line --##
+run_native: False
+
 ##-- Final output file prefixes for overall run --##
 ##-- If none given, run_prefix is used (default: date_time_aquatx) --##
 output_prefix: ~
@@ -168,7 +175,8 @@ fasta: True
 sam: True
 
 ##-- If True: use shared mem for index; many bowtie's can share --##
-shared_memory: True
+##-- Note: this requires further configuration of your OS; see ipcs and ipcrm --#
+shared_memory: False
 
 ###-- Unused option inputs: Remove '#' in front to use --###
 ##-- If true: do not align to reverse-compliment reference --##

--- a/tests/unit_tests_aquatx.py
+++ b/tests/unit_tests_aquatx.py
@@ -47,7 +47,9 @@ class test_aquatx(unittest.TestCase):
                     }
                 },
                 'workflows': {
-                    'files': {'aquatx_wf.cwl'}
+                    'files': {
+                        'aquatx_wf.cwl', 'per-library.cwl'
+                    }
                 }
             }
         }
@@ -189,6 +191,7 @@ class test_aquatx(unittest.TestCase):
                 for i in range(10):
                     time.sleep(1)
                     sub_names = [sub.name() for sub in get_children()]
+                    print(sub_names)
                     if 'cwltool' in sub_names:
                         break
 


### PR DESCRIPTION
Closes #28 

Adds 
- Options to use Python-native use of cwltool, rather than invoking cwltool via the command line
- Parallel execution of the pipeline via the cwltool runner (Python-native mode only to allow for greater control over concurrency in later development)
- Redesigned pipeline workflow. The pipeline now executes library-by-library for fastp, bowtie, and collapser. This will result in much better runtimes for sample sets with large differences in length.

Fixes:
- cwltool is now able to properly collect output files with special characters in their name. Previously this had caused the pipeline to fail at the Counter step since 5' NT/length tables are written to filenames containing parentheses. See note about toil[cwl] in remaining issues below

Remaining issues
- The current release of Toil will eventually produce an error on the Counter step. This is due to limitations on Unix path length which are exceeded when both Toil and Python Multiprocessing combine their temporary directory paths. It appears there is a fix for this in the Toil repo but it has not been made available in a release at this time.
-- Potential workaround: Docker containers.
- pip install "toil[cwl]" will install the previous version of cwltool. The last two versions of cwltool suffer from a bug where output filenames containing special characters end up being URL encoded. The current version properly identifies the output file and simply copies it under the URL encoded name. The version installed by Toil (previous version of cwltool) searches for the URL encoded filename in tmpdir and fails to find it since outputs in tmpdir have proper non-encoded names.
-- Workaround: cwltool 3.1 is required