### PR TITLE
Improvements and fixes for Counter

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -212,6 +212,9 @@ shared_memory: False
 ##-- If True: save intermediate table for each library with all alignment information --##
 intermed_file: False
 
+##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
+counter_diags: False
+
 
 ######--------------------------- DIFFERENTIAL EXPRESSION ---------------------------######
 #
@@ -220,7 +223,7 @@ intermed_file: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: produce principal component analysis plots for each sample comparison
+##-- If True: produce principal component analysis plots for each sample comparison --##
 dge_pca_plots: true
 
 

--- a/aquatx/cwl/tools/aquatx-count.cwl
+++ b/aquatx/cwl/tools/aquatx-count.cwl
@@ -47,6 +47,13 @@ inputs:
       position: 4
       prefix: -p
 
+  diagnostics:
+    type: boolean?
+    default: false
+    inputBinding:
+      position: 5
+      prefix: -d
+
   # The following optional inputs are for staging InitialWorkingDir files for pipeline execution
 
   # Specifies the GFF files defined in features.csv
@@ -90,3 +97,13 @@ outputs:
     type: File[]?
     outputBinding:
       glob: "*_aln_table.txt"
+
+  alignment_diags:
+    type: File?
+    outputBinding:
+      glob: $(inputs.out_prefix)_alignment_diags.csv
+
+  selection_diags:
+    type: File?
+    outputBinding:
+      glob: $(inputs.out_prefix)_selection_diags.txt

--- a/aquatx/cwl/workflows/aquatx_wf.cwl
+++ b/aquatx/cwl/workflows/aquatx_wf.cwl
@@ -80,6 +80,7 @@ inputs:
   gff_files: File[]?
   aligned_seqs: File[]?
   is_pipeline: boolean?
+  counter_diags: boolean?
 
   # deseq inputs
   dge_pca_plots: boolean?
@@ -211,7 +212,8 @@ steps:
       fastp_logs: counter-prep/json_report_file
       collapsed_fa: counter-prep/uniq_seqs
       is_pipeline: {default: true}
-    out: [feature_counts, other_counts, alignment_stats, summary_stats, intermed_out_files]
+      diagnostics: counter_diags
+    out: [feature_counts, other_counts, alignment_stats, summary_stats, intermed_out_files, alignment_diags, selection_diags]
 
   dge:
     run: ../tools/aquatx-deseq.cwl
@@ -243,6 +245,12 @@ steps:
       counter_summary_stats: counter/summary_stats
       counter_intermed:
         source: counter/intermed_out_files
+        default: []
+      counter_aln_diag:
+        source: counter/alignment_diags
+        default: []
+      counter_selection_diag:
+        source: counter/selection_diags
         default: []
       features_csv: features_csv
 

--- a/aquatx/cwl/workflows/organize-outputs.cwl
+++ b/aquatx/cwl/workflows/organize-outputs.cwl
@@ -39,6 +39,8 @@ inputs:
   counter_alignment_stats: File?
   counter_summary_stats: File?
   counter_intermed: File[]?
+  counter_aln_diag: File?
+  counter_selection_diag: File?
 
   dge_name: string?
   dge_norm: File?
@@ -93,7 +95,8 @@ steps:
     when: $(inputs.dir_name != null)
     in:
       dir_files:
-        source: [ counter_features, counter_other, counter_alignment_stats, counter_summary_stats, counter_intermed, features_csv ]
+        source: [ counter_features, counter_other, counter_alignment_stats, counter_summary_stats,
+                  counter_intermed, counter_aln_diag, counter_selection_diag, features_csv ]
         linkMerge: merge_flattened
       dir_name: counter_name
     out: [ subdir ]

--- a/aquatx/extras/run_config_template.yml
+++ b/aquatx/extras/run_config_template.yml
@@ -212,6 +212,9 @@ shared_memory: False
 ##-- If True: save intermediate table for each library with all alignment information --##
 intermed_file: False
 
+##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
+counter_diags: False
+
 
 ######--------------------------- DIFFERENTIAL EXPRESSION ---------------------------######
 #
@@ -220,7 +223,7 @@ intermed_file: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: produce principal component analysis plots for each sample comparison
+##-- If True: produce principal component analysis plots for each sample comparison --##
 dge_pca_plots: true
 
 

--- a/aquatx/srna/counter/FeatureSelector.py
+++ b/aquatx/srna/counter/FeatureSelector.py
@@ -38,6 +38,7 @@ class FeatureSelector:
         self.interest = ('Identity', 'Strand', 'nt5', 'Length')
         self.rules_table = sorted(rules, key=lambda x: x['Hierarchy'])
         self.build_filters()
+        self.diag = None
 
         # Inverted ident rules: (Attrib Key, Attrib Val) as key, [associated rules] as val
         inverted_identities = defaultdict(list)
@@ -59,6 +60,9 @@ class FeatureSelector:
             for hit in finalists:
                 if read not in self.rules_table[hit[self.rule]][step]:
                     eliminated.add(hit)
+                    if self.diag is not None:
+                        feat_class = self.attributes[hit[self.feat]][0][1][0]
+                        self.diag[feat_class][f"{step}={read}"] += 1
 
             finalists -= eliminated
             eliminated.clear()

--- a/aquatx/srna/counter/counter.py
+++ b/aquatx/srna/counter/counter.py
@@ -1,11 +1,9 @@
-import functools
 import multiprocessing as mp
-import argparse
-import sys
 import traceback
-
+import argparse
 import HTSeq
 import queue
+import sys
 import csv
 import os
 
@@ -50,20 +48,15 @@ def get_args():
     arg_parser.add_argument('-p', '--is-pipeline', action='store_true',
                         help='Indicates that counter was invoked from the aquatx pipeline '
                              'and that input files should be sources as such.')
-    arg_parser.add_argument('-s', '--strandedness', choices=['forward', 'reverse', 'infer'], default='reverse',
-                        help='Indicates the library preparation method used. Most modern '
-                             'library preparation methods use first strand cDNA synthesis, '
-                             'or the "reverse" option. If you aren\'t sure, choose "infer"')
     arg_parser.add_argument('-d', '--diagnostics', action='store_true',
                         help='Produce diagnostic information about uncounted/eliminated '
                              'selection elements.')
 
     parsed_args = arg_parser.parse_args()
 
-    global is_pipeline, run_diags, stranded
+    global is_pipeline, run_diags
     is_pipeline = parsed_args.is_pipeline
     run_diags = parsed_args.diagnostics
-    stranded = parsed_args.strandedness
     return arg_parser.parse_args()
 
 

--- a/aquatx/srna/counter/statistics.py
+++ b/aquatx/srna/counter/statistics.py
@@ -4,7 +4,7 @@ import sys
 import os
 
 from typing import Tuple, Union
-from collections import Counter
+from collections import Counter, defaultdict
 
 from .FeatureSelector import FeatureSelector
 from .hts_parsing import Alignment
@@ -27,14 +27,17 @@ class LibraryStats:
                           'Reads Assigned to Multiple Features', 'Sequences Assigned to Multiple Features',
                           'Total Unassigned Reads', 'Total Unassigned Sequences']
 
-    def __init__(self, library: dict, out_prefix: str = None, save_intermediate_file: bool = False):
+    def __init__(self, library: dict, out_prefix: str = None, save_intermediate_file: bool = False, diag: bool = False):
         self.library = library
         self.out_prefix = out_prefix
         self.save_intermediate_file = save_intermediate_file
+        self.diag = diag
 
         self.feat_counts = Counter()
         self.nt_len_mat = {nt: Counter() for nt in ['A', 'T', 'G', 'C']}
         self.library_stats = {stat: 0 for stat in LibraryStats.summary_categories}
+        self.alignment_diags = {stat: 0 for stat in SummaryStats.aln_diag_categories}
+        self.selection_diags = defaultdict(Counter)
         self.alignments = []
 
     def count_bundle(self, aln_bundle: iter) -> Bundle:
@@ -53,7 +56,7 @@ class LibraryStats:
 
         return self.Bundle(loci_counts, read_counts, corr_counts)
 
-    def count_bundle_alignments(self, bundle: Bundle, aln: Alignment, assignments: set) -> None:
+    def count_bundle_alignments(self, bundle: Bundle, aln: Alignment, assignments: set, n_candidates: int) -> None:
         """Called for each alignment for each read"""
 
         assigned_count = len(assignments)
@@ -78,6 +81,8 @@ class LibraryStats:
 
         if self.save_intermediate_file:
             self.record_alignment_details(aln, bundle, assignments)
+        if self.diag:
+            self.record_diagnostics(assignments, n_candidates, aln, bundle)
 
     def finalize_bundle(self, bundle: Bundle) -> None:
         """Called at the conclusion of processing each multiple-alignment bundle"""
@@ -121,14 +126,31 @@ class LibraryStats:
                 map(lambda rec: "%s\t%f\t%c\t%d\t%d\t%s\n" % rec, self.alignments)
             )
 
+    def record_diagnostics(self, assignments, n_candidates, aln, bundle):
+        """Records basic diagnostic info"""
+
+        if len(assignments) == 0:
+            if aln.iv.strand == '+':
+                self.alignment_diags['Uncounted alignments (+)'] += 1
+            else:
+                self.alignment_diags['Uncounted alignments (-)'] += 1
+            if n_candidates == 0:
+                self.alignment_diags['No feature counts'] += bundle.corr_count
+            else:
+                self.alignment_diags['Eliminated counts'] += bundle.corr_count
+
 
 class SummaryStats:
 
     summary_categories = ["Total Reads", "Retained Reads", "Unique Sequences",
                           "Mapped Sequences", "Mapped Reads", "Aligned Reads"]
 
-    def __init__(self, out_prefix):
+    aln_diag_categories = ['Eliminated counts', 'No feature counts',
+                           'Uncounted alignments (+)', 'Uncounted alignments (-)']
+
+    def __init__(self, out_prefix, report_diagnostics=False):
         self.out_prefix = out_prefix
+        self.diag = report_diagnostics
 
         # Will become False if an added library lacks its corresponding Collapser and Bowtie outputs
         self.report_summary_statistics = True
@@ -136,6 +158,8 @@ class SummaryStats:
         self.pipeline_stats_df = pd.DataFrame(index=SummaryStats.summary_categories)
         self.feat_counts_df = pd.DataFrame(index=FeatureSelector.attributes.keys())
         self.lib_stats_df = pd.DataFrame(index=LibraryStats.summary_categories)
+        self.aln_diags = pd.DataFrame(columns=SummaryStats.aln_diag_categories)
+        self.selection_diags = {}
         self.nt_len_mat = {}
 
     def write_report_files(self, alias: dict, prefix=None) -> None:
@@ -143,6 +167,7 @@ class SummaryStats:
         self.write_alignment_statistics(prefix)
         self.write_pipeline_statistics(prefix)
         self.write_feat_counts(alias, prefix)
+        self.write_diagnostics(prefix)
         self.write_nt_len_mat(prefix)
 
     def write_alignment_statistics(self, prefix: str) -> None:
@@ -188,6 +213,23 @@ class SummaryStats:
 
         summary.to_csv(prefix + '_feature_counts.csv', index=False)
 
+    def write_diagnostics(self, prefix: str) -> None:
+        if not self.diag: return
+        self.aln_diags = self.sort_cols_and_round(self.aln_diags, "index")
+        self.aln_diags.index.name = "Sample"
+        self.aln_diags.to_csv(prefix + "_alignment_diags.csv")
+
+        out = []
+        for lib in sorted(self.selection_diags.keys()):
+            out.append(lib)
+            for feat_class in sorted(self.selection_diags[lib].keys()):
+                out.append('\t' + feat_class)
+                for stat in sorted(self.selection_diags[lib][feat_class].keys()):
+                    out.append("\t\t%s: %d" % (stat, self.selection_diags[lib][feat_class][stat]))
+
+        with open(prefix + "_selection_diags.txt", 'w') as f:
+            f.write('\n'.join(out))
+
     def write_nt_len_mat(self, prefix: str) -> None:
         """Writes each library's 5' end nucleotide / length matrix to its own file."""
 
@@ -202,6 +244,8 @@ class SummaryStats:
         self.feat_counts_df[other.library["Name"]] = self.feat_counts_df.index.map(other.feat_counts)
         self.lib_stats_df[other.library["Name"]] = self.lib_stats_df.index.map(other.library_stats)
         self.nt_len_mat[other.library["Name"]] = other.nt_len_mat
+
+        if self.diag: self.add_diags(other)
 
         # Process pipeline step outputs for this library, if they exist, to provide Summary Statistics
         if self.report_summary_statistics and self.library_has_pipeline_outputs(other):
@@ -226,6 +270,13 @@ class SummaryStats:
             }
 
             self.pipeline_stats_df[other.library["Name"]] = self.pipeline_stats_df.index.map(other_summary)
+
+    def add_diags(self, other: LibraryStats) -> None:
+        """Append alignment and selection diagnostics to the master tables"""
+
+        other_lib = other.library['Name']
+        self.selection_diags[other_lib] = other.selection_diags
+        self.aln_diags.loc[other_lib] = other.alignment_diags
 
     def library_has_pipeline_outputs(self, other: LibraryStats) -> bool:
         """Check working directory for pipeline outputs from previous steps"""
@@ -285,7 +336,6 @@ class SummaryStats:
             return "err"
 
     @staticmethod
-    def sort_cols_and_round(df: pd.DataFrame) -> pd.DataFrame:
+    def sort_cols_and_round(df: pd.DataFrame, axis="columns") -> pd.DataFrame:
         """Convenience function to sort columns by title and round all values to 2 decimal places"""
-        sorted_columns = sorted(df.columns)
-        return df.round(decimals=2).reindex(sorted_columns, axis="columns")
+        return df.round(decimals=2).sort_index(axis=axis)

--- a/aquatx/srna/resume.py
+++ b/aquatx/srna/resume.py
@@ -24,9 +24,9 @@ class ResumeConfig(ConfigBase, ABC):
     def __init__(self, processed_config, workflow, steps, entry_inputs):
         # Parse the pre-processed YAML configuration file
         super().__init__(processed_config)
-        self.check_dir_requirements(processed_config)
+        self.check_dir_requirements()
 
-        # Load the CWL workflow YAML for modification
+        # Load the workflow YAML for modification
         if '~' in workflow: os.path.expanduser(workflow)
         with open(workflow, 'r') as f:
             self.workflow: CommentedOrderedMap
@@ -40,14 +40,13 @@ class ResumeConfig(ConfigBase, ABC):
         self._rebuild_entry_inputs()
         self._add_timestamps()
 
-    def check_dir_requirements(self, config_file):
+    def check_dir_requirements(self):
         """Ensure that user has invoked this command from within the target run directory"""
 
         target_run_dir = os.path.basename(self['run_directory'])
-        config_file_dir = os.path.dirname(config_file)
         invocation_dir = os.path.basename(os.getcwd())
 
-        if config_file_dir != '' or invocation_dir != target_run_dir:
+        if invocation_dir != target_run_dir:
             sys.exit("Resume commands must be executed from within the target Run Directory.")
 
     @abstractmethod
@@ -136,7 +135,7 @@ class ResumeCounterConfig(ResumeConfig):
             'collapsed_fa': {'var': "resume_collapsed_fas", 'type': "File[]"},
         }
 
-        # Parse the pre-processed YAML configuration file
+        # Build resume config from the previously-processed Run Config
         super().__init__(processed_config, workflow, steps, inputs)
 
     def _rebuild_entry_inputs(self):
@@ -172,7 +171,7 @@ class ResumePlotterConfig(ResumeConfig):
             'len_dist': {'var': "resume_len_dist", 'type': "File[]"}
         }
 
-        # Parse the pre-processed YAML configuration file
+        # Build resume config from the previously-processed Run Config
         super().__init__(processed_config, workflow, steps, inputs)
 
     def _rebuild_entry_inputs(self):

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -212,6 +212,9 @@ shared_memory: False
 ##-- If True: save intermediate table for each library with all alignment information --##
 intermed_file: False
 
+##-- If True: produce diagnostic logs to indicate what was eliminated and why --##
+counter_diags: False
+
 
 ######--------------------------- DIFFERENTIAL EXPRESSION ---------------------------######
 #
@@ -220,7 +223,7 @@ intermed_file: False
 ######-------------------------------------------------------------------------------######
 
 
-##-- If True: produce principal component analysis plots for each sample comparison
+##-- If True: produce principal component analysis plots for each sample comparison --##
 dge_pca_plots: true
 
 

--- a/tests/unit_tests_counter.py
+++ b/tests/unit_tests_counter.py
@@ -231,6 +231,38 @@ class CounterTests(unittest.TestCase):
         self.assertEqual(matches_with_cooridnates[0][0], HTSeq.GenomicInterval("I", 9,10,'+'))
         self.assertEqual(matches_with_cooridnates[1][0], HTSeq.GenomicInterval("I", 10,15,'+'))
         self.assertEqual(matches_with_cooridnates[2][0], HTSeq.GenomicInterval("I", 15,20,'+'))
+        self.assertEqual(matches_with_cooridnates[2][0], HTSeq.GenomicInterval("I", 15,20,'+'))
+
+    """What happens if we invert the previous test's strand? Do intervals behave differently?"""
+
+    def test_HTSeq_antisense_iv_slice(self):
+        gas = HTSeq.GenomicArrayOfSets("auto", stranded=True)
+        iva = HTSeq.GenomicInterval("I", 1, 10, '-')
+        ivb = HTSeq.GenomicInterval("I", 5, 15, '-')
+        ivc = HTSeq.GenomicInterval("I", 9, 20, '-')
+        ivd = HTSeq.GenomicInterval("I", 2, 4, "-")
+        gas[iva] += "TestA"
+        gas[ivb] += "TestB"
+        gas[ivd] += "TestD"
+
+        """
+        iva:  1 |--TestA--| 10
+        ivb:      5 |---TestB--| 15
+        ivc:          9 |-----------| 20
+        ivd:   2 |--| 4
+                         ^ Single base overlap: iva ∩ ivc
+        Expect:       9 |-|{B}-|-{}-| 20
+                     [9, 10)   [15,20)
+                         ^ {A ∩ B}
+        """
+
+        matches = list(gas[ivc].array[ivc.start:ivc.end].get_steps(values_only=True))
+        matches_with_cooridnates = list(gas[ivc].steps())
+        self.assertEqual(matches, [{"TestA", "TestB"}, {"TestB"}, set()])
+        self.assertEqual(matches_with_cooridnates[0][0], HTSeq.GenomicInterval("I", 9,10,'-'))
+        self.assertEqual(matches_with_cooridnates[1][0], HTSeq.GenomicInterval("I", 10,15,'-'))
+        self.assertEqual(matches_with_cooridnates[2][0], HTSeq.GenomicInterval("I", 15,20,'-'))
+        self.assertEqual(matches_with_cooridnates[2][0], HTSeq.GenomicInterval("I", 15,20,'-'))
 
     """Does assign_features return features that overlap the query interval by a single base?"""
 

--- a/tests/unit_tests_counter.py
+++ b/tests/unit_tests_counter.py
@@ -267,10 +267,10 @@ class CounterTests(unittest.TestCase):
     """Does assign_features return features that overlap the query interval by a single base?"""
 
     def test_assign_features_single_base_overlap(self):
-        features = HTSeq.GenomicArrayOfSets("auto", stranded=True)
-        iv_feat = HTSeq.GenomicInterval("I", 0, 2, "+")  # The "feature"
-        iv_olap = HTSeq.GenomicInterval("I", 1, 2, "+")  # A single-base overlapping feature
-        iv_none = HTSeq.GenomicInterval("I", 2, 3, "+")  # A non-overlapping interval
+        features = HTSeq.GenomicArrayOfSets("auto", stranded=False)
+        iv_feat = HTSeq.GenomicInterval("I", 0, 2, ".")  # The "feature"
+        iv_olap = HTSeq.GenomicInterval("I", 1, 2, ".")  # A single-base overlapping feature
+        iv_none = HTSeq.GenomicInterval("I", 2, 3, ".")  # A non-overlapping interval
 
         features[iv_feat] += 'The "feature"'
         features[iv_none] += "Non-overlapping feature"
@@ -287,9 +287,9 @@ class CounterTests(unittest.TestCase):
     """Does assign_features correctly handle alignments with zero feature matches?"""
 
     def test_assign_features_no_match(self):
-        features = HTSeq.GenomicArrayOfSets("auto", stranded=True)
-        iv_feat = HTSeq.GenomicInterval("I", 0, 2, "+")
-        iv_none = HTSeq.GenomicInterval("I", 2, 3, "+")
+        features = HTSeq.GenomicArrayOfSets("auto", stranded=False)
+        iv_feat = HTSeq.GenomicInterval("I", 0, 2, ".")
+        iv_none = HTSeq.GenomicInterval("I", 2, 3, ".")
 
         features[iv_feat] += "Should not match"
         none_alignment = Alignment(iv_none, "Non-overlap", b"A")
@@ -314,9 +314,9 @@ class CounterTests(unittest.TestCase):
 
         expected_calls_to_stats = [
             call(),  # Produced above when grabbing the return value of count_bundle
-            call(library, None, False),  # Call to constructor
+            call(library, None, False, False),  # Call to constructor
             call().count_bundle([alignment]),
-            call().count_bundle_alignments(bundle, alignment, {'mock_feat'}),
+            call().count_bundle_alignments(bundle, alignment, {'mock_feat'}, len({'mock_feat'})),
             call().finalize_bundle(bundle)
         ]
 

--- a/tests/unit_tests_entry.py
+++ b/tests/unit_tests_entry.py
@@ -63,7 +63,8 @@ class test_aquatx(unittest.TestCase):
             helpers.LambdaCapture(lambda: aquatx.get_template(self.aquatx_extras_path)),  # The pre-install invocation
             helpers.ShellCapture("aquatx get-template")                                   # The post-install command
         ]
-        template_files = ['run_config_template.yml', 'samples.csv', 'features.csv', 'paths.yml']
+        template_files = ['run_config_template.yml', 'samples.csv', 'features.csv',
+                          'paths.yml', 'aquatx-srna-light.mplstyle']
 
         def dir_entry_ct():
             return len(os.listdir('.'))
@@ -75,10 +76,10 @@ class test_aquatx(unittest.TestCase):
                 with test_context as test:
                     test()
 
-                # Check that exactly 4 files were produced by the command
+                # Check that exactly 5 files were produced by the command
                 self.assertEqual(
                     dir_entry_ct() - dir_before_count, len(template_files),
-                    f"Abnormal number of template files. Expected 4. Function: {test_context}")
+                    f"Abnormal number of template files. Function: {test_context}")
 
                 # Check that each expected file was produced
                 for file in template_files:

--- a/tests/unit_tests_hts_parsing.py
+++ b/tests/unit_tests_hts_parsing.py
@@ -155,18 +155,6 @@ class MyTestCase(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, expected_err):
             build_reference_tables(feature_source, selection_rules)
 
-    """Does build_reference_tables raise ValueError when it encounters a GFF entry without strand information?"""
-
-    def test_ref_tables_unstranded(self):
-        gff_file = f"{resources}/unstranded.gff3"
-        feature_source = {gff_file: ["ID"]}
-        selection_rules = []
-
-        expected_err = f"Feature Gene:WBGene00023193 in {gff_file} has no strand information."
-
-        with self.assertRaisesRegex(ValueError, expected_err):
-            build_reference_tables(feature_source, selection_rules)
-
     """Does build_reference_tables properly concatenate aliases if there is more than one alias for a feature?"""
     """Does build_reference_tables properly concatenate aliases when Name Attribute refers to a list-type alias?"""
     # 2 for 1!


### PR DESCRIPTION
This PR changes the approach Counter uses to resolve SAM record intervals -> features. This resolution is now strandless. Features parsed from GFF files are stored strandless. Only the SAM record's strand information is retained and used during selection. Previously, features were resolved in a strand-specific way that does not make sense for our strand selection parameters in Features Sheet.

Counter now supports printing detailed diagnostics about eliminations that took place. Two new logfiles are produced with the `-d` command line option:
- {prefix}_alignment_diags.csv
    - **Eliminated counts**: when features were associated with an alignment, but none of these features passed selection, this value is incremented by the alignment's corr_count (reads / loci)
    - **No feature counts**: when no features were associated with an alignment, this value is incremented by the alignment's corr_count
    - **Uncounted alignments (+)** and **Uncounted alignments (-)**: when no features were associated with an alignment, this value is incremented by one depending on the alignment's strand
- {prefix}_selection_diags.txt
    - Pertains to phase 2 selection only
    - When a feature is eliminated based on a sequence attribute, a record is created which indicates the sequence attribute and what its value was. The record is a counter which is incremented each time this happens. These records are organized by class for each library, but they do NOT indicate that the class had anything to do with the elimination -- it's just what the feature's class happened to be