### PR TITLE
Improved Counter feature counts table

### DIFF
--- a/aquatx/cwl/workflows/aquatx_wf.cwl
+++ b/aquatx/cwl/workflows/aquatx_wf.cwl
@@ -246,12 +246,8 @@ steps:
       counter_intermed:
         source: counter/intermed_out_files
         default: []
-      counter_aln_diag:
-        source: counter/alignment_diags
-        default: []
-      counter_selection_diag:
-        source: counter/selection_diags
-        default: []
+      counter_aln_diag: counter/alignment_diags
+      counter_selection_diag: counter/selection_diags
       features_csv: features_csv
 
       dge_name: dir_name_dge

--- a/aquatx/cwl/workflows/organize-outputs.cwl
+++ b/aquatx/cwl/workflows/organize-outputs.cwl
@@ -16,6 +16,7 @@ requirements:
 inputs:
 
   bt_build_name: string?
+  run_bowtie_build: boolean?
   bt_build_indexes: File[]?
 
   fastp_name: string?
@@ -54,8 +55,9 @@ steps:
 
   organize_bt_indexes:
     run: ../tools/make-subdir.cwl
-    when: $(inputs.dir_name != null)
+    when: $(inputs.run_bowtie_build)
     in:
+      run_bowtie_build: {source: run_bowtie_build, default: false}
       dir_files: bt_build_indexes
       dir_name: bt_build_name
     out: [ subdir ]

--- a/aquatx/srna/counter/FeatureSelector.py
+++ b/aquatx/srna/counter/FeatureSelector.py
@@ -5,10 +5,13 @@ import re
 from collections import defaultdict, Counter
 from typing import List, Tuple, FrozenSet, Dict, Set
 
-from aquatx.srna.counter.hts_parsing import Alignment
+from .hts_parsing import Alignment
 
 # Type aliases for human readability
 IntervalFeatures = Tuple[int, int, Set[str]]  # A set of features associated with an interval
+
+# Global indexes for Hits produced by choose_identity()
+RANK, RULE, FEAT = 0, 1, 2
 
 
 class FeatureSelector:
@@ -32,7 +35,6 @@ class FeatureSelector:
     by the alignment interval.
     """
 
-    rank, rule, feat = 0, 1, 2
     attributes = {}
 
     def __init__(self, rules: List[dict], reference_table: Dict):
@@ -47,8 +49,9 @@ class FeatureSelector:
             inverted_identities[rule['Identity']].append(i)
         self.inv_ident = dict(inverted_identities)
 
-        self.report_diags = False
-        self.report: defaultdict['Counter']
+        self.report_eliminations = False
+        self.elim_stats: defaultdict['Counter']
+        self.phase1_candidates: set
 
     def choose(self, feat_list: List[IntervalFeatures], alignment: 'Alignment') -> set:
         # Perform hierarchy-based first round of selection for identities
@@ -62,11 +65,11 @@ class FeatureSelector:
         eliminated = set()
         for step, read in zip(self.interest[1:], (strand, nt5end, length)):
             for hit in finalists:
-                if read not in self.rules_table[hit[self.rule]][step]:
+                if read not in self.rules_table[hit[RULE]][step]:
                     eliminated.add(hit)
-                    if self.report_diags:
-                        feat_class = self.attributes[hit[self.feat]][0][1][0]
-                        self.report[feat_class][f"{step}={read}"] += 1
+                    if self.report_eliminations:
+                        feat_class = self.attributes[hit[FEAT]][0][1][0]
+                        self.elim_stats[feat_class][f"{step}={read}"] += 1
 
             finalists -= eliminated
             eliminated.clear()
@@ -74,7 +77,7 @@ class FeatureSelector:
             if not finalists: return set()
 
         # Remaining finalists have passed all filters
-        return {choice[self.feat] for choice in finalists}
+        return {choice[FEAT] for choice in finalists}
 
     @staticmethod
     def is_perfect_iv_match(feat_start, feat_end, aln_iv):
@@ -124,19 +127,21 @@ class FeatureSelector:
                             pass
         # -> identity_hits: [(hierarchy, rule, feature), ...]
 
+        self.phase1_candidates.update(hit[FEAT] for hit in identity_hits)
+
         # Only one feature matched only one rule
         if len(identity_hits) == 1:
             finalists.add(identity_hits[0])
         # Perform any possible hierarchy-based eliminations
         elif len(identity_hits) > 1:
-            uniq_ranks = {hit[self.rank] for hit in identity_hits}
+            uniq_ranks = {hit[RANK] for hit in identity_hits}
 
             if len(identity_hits) == len(uniq_ranks):
-                finalists.add(min(identity_hits, key=lambda x: x[self.rank]))
+                finalists.add(min(identity_hits, key=lambda x: x[RANK]))
             else:
                 # Two or more hits share the same hierarchy.
                 min_rank = min(uniq_ranks)
-                finalists.update(hit for hit in identity_hits if hit[self.rank] == min_rank)
+                finalists.update(hit for hit in identity_hits if hit[RANK] == min_rank)
 
         return finalists
 
@@ -179,12 +184,15 @@ class FeatureSelector:
                 if not wildcard(step):
                     row[step] = filt()
 
-    def enable_diagnostics(self, libstats_selection_diags):
+    def set_stats_collectors(self, libstats: 'LibraryStats', diags=False):
         """Enables diagnostic reporting for eliminations made in selection phase 2"""
-        self.report = libstats_selection_diags
-        self.report_diags = True
+
+        self.phase1_candidates = libstats.identity_roster
+        if diags:
+            self.elim_stats = libstats.selection_diags
+            self.report_eliminations = diags
 
     @classmethod
     def get_hit_indexes(cls):
         """Hits are stored as tuples for performance. This returns a human friendly index map for the tuple."""
-        return cls.rank, cls.rule, cls.feat
+        return RANK, RULE, FEAT

--- a/aquatx/srna/counter/counter.py
+++ b/aquatx/srna/counter/counter.py
@@ -161,7 +161,7 @@ def count_reads(library: dict, return_queue: mp.Queue, intermediate_file: bool =
     # 2. Change FeatureSelector.choose() to assign nt5end from chr(alignment.read.seq[0])
     read_seq = parser.read_SAM(library["File"])
     stats = LibraryStats(library, out_prefix, intermediate_file, run_diags)
-    if run_diags: selector.enable_diagnostics(stats.selection_diags)
+    selector.set_stats_collectors(stats, diags=run_diags)
 
     # For each sequence in the sam file...
     # Note: HTSeq only performs bundling. The alignments are our own Alignment objects


### PR DESCRIPTION
Counter's feature counts table now undergoes an additional filtering step.
Rather than displaying all features parsed from GFF files (including zero count features), we now show only the features that matched an identity rule in the Features Sheet.
- This includes features that have zero counts (due to hierarchy eliminations in phase 1 or elimination in phase 2)
- This does NOT include GFF features that match on identity but were not encountered in SAM alignments