### PR TITLE
Terminal output control/cleanup and Plotter improvements

### DIFF
--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -224,7 +224,7 @@ counter_diags: False
 
 
 ##-- If True: produce principal component analysis plots for each sample comparison --##
-dge_pca_plots: true
+dge_pca_plots: True
 
 
 ######-------------------------------- PLOTTING OPTIONS -----------------------------######
@@ -248,7 +248,7 @@ plot_requests:
   - 'replicate_scatter'
   - 'sample_avg_scatter'
   - 'sample_avg_scatter_by_class'
-  - 'sample_avg_scatter_by_deg'
+  - 'sample_avg_scatter_by_dge'
   - 'sample_avg_scatter_by_both'
 
 ##-- You may supply your own matplotlib style sheet to override defaults here --##

--- a/START_HERE/run_config.yml
+++ b/START_HERE/run_config.yml
@@ -36,8 +36,8 @@ run_bowtie_build: True
 ##-- For best performance, this should be equal to your computer's processor core count --##
 threads: 4
 
-##-- If True: cwltool will print detailed workflow operation details --##
-debug: False
+##-- Control the amount of information printed to terminal: debug, normal, quiet --##
+verbosity: normal
 
 ##-- (EXPERIMENTAL) If True: process each sample library in parallel --##
 run_parallel: False

--- a/aquatx/cwl/tools/aquatx-plot.cwl
+++ b/aquatx/cwl/tools/aquatx-plot.cwl
@@ -18,10 +18,10 @@ inputs:
       prefix: -nc
     doc: "Normalized feature counts from DESeq"
 
-  deg_tables:
+  dge_tables:
     type: File[]
     inputBinding:
-      prefix: -deg
+      prefix: -dge
     doc: "Sample comparison tables from DESeq"
 
   len_dist:

--- a/aquatx/cwl/tools/make-subdir.cwl
+++ b/aquatx/cwl/tools/make-subdir.cwl
@@ -19,8 +19,8 @@ requirements:
 arguments: [":"]
 
 inputs:
-  dir_files: File[]?
-  dir_name: string
+  dir_files: File[]
+  dir_name: {type: string?, default: "default_dirname"}
 
 outputs:
   subdir:

--- a/aquatx/cwl/workflows/aquatx_wf.cwl
+++ b/aquatx/cwl/workflows/aquatx_wf.cwl
@@ -226,7 +226,7 @@ steps:
     in:
       raw_counts: counter/feature_counts
       norm_counts: dge/norm_counts
-      deg_tables: dge/comparisons
+      dge_tables: dge/comparisons
       len_dist: counter/other_counts
       style_sheet: plot_style_sheet
       out_prefix: run_name

--- a/aquatx/cwl/workflows/aquatx_wf.cwl
+++ b/aquatx/cwl/workflows/aquatx_wf.cwl
@@ -195,9 +195,7 @@ steps:
       bowtie_name: dir_name_bowtie
       bowtie_sam: counter-prep/aln_seqs
       bowtie_log: counter-prep/bowtie_log
-      bowtie_unal:
-        source: counter-prep/unal_seqs
-        default: [ ]
+      bowtie_unal: counter-prep/unal_seqs
     out: [ bt_build_dir, fastp_dir, collapser_dir, bowtie_dir ]
 
   counter:
@@ -220,7 +218,7 @@ steps:
     in:
       input_file: counter/feature_counts
       outfile_prefix: run_name
-      pca: dge_pca_plots
+      plots: dge_pca_plots
     out: [ norm_counts, comparisons, pca_plots ]
 
   plotter:
@@ -243,9 +241,7 @@ steps:
       counter_other: counter/other_counts
       counter_alignment_stats: counter/alignment_stats
       counter_summary_stats: counter/summary_stats
-      counter_intermed:
-        source: counter/intermed_out_files
-        default: []
+      counter_intermed: counter/intermed_out_files
       counter_aln_diag: counter/alignment_diags
       counter_selection_diag: counter/selection_diags
       features_csv: features_csv
@@ -253,14 +249,10 @@ steps:
       dge_name: dir_name_dge
       dge_norm: dge/norm_counts
       dge_comparisons: dge/comparisons
-      dge_pca:
-        source: dge/pca_plots
-        default: []
+      dge_pca: dge/pca_plots
 
       plotter_name: dir_name_plotter
-      plotter_plots:
-        source: plotter/plots
-        default: []
+      plotter_plots: plotter/plots
     out: [ counter_dir, dge_dir, plotter_dir ]
 
 outputs:

--- a/aquatx/cwl/workflows/aquatx_wf.cwl
+++ b/aquatx/cwl/workflows/aquatx_wf.cwl
@@ -187,10 +187,7 @@ steps:
 
       collapser_name: dir_name_collapser
       collapser_uniq: counter-prep/uniq_seqs
-      collapser_low:
-        # Due to scatter, this optional output is actually an array of nulls when not produced (can't use default)
-        source: counter-prep/uniq_seqs_low
-        pickValue: all_non_null
+      collapser_low: counter-prep/uniq_seqs_low
 
       bowtie_name: dir_name_bowtie
       bowtie_sam: counter-prep/aln_seqs

--- a/aquatx/cwl/workflows/organize-outputs.cwl
+++ b/aquatx/cwl/workflows/organize-outputs.cwl
@@ -69,6 +69,7 @@ steps:
       dir_files:
         source: [ fastp_cleaned_fastq, fastp_html_report, fastp_json_report ]
         linkMerge: merge_flattened
+        pickValue: all_non_null
       dir_name: fastp_name
     out: [ subdir ]
 
@@ -79,6 +80,7 @@ steps:
       dir_files:
         source: [ collapser_uniq, collapser_low ]
         linkMerge: merge_flattened
+        pickValue: all_non_null
       dir_name: collapser_name
     out: [ subdir ]
 
@@ -89,6 +91,7 @@ steps:
       dir_files:
         source: [ bowtie_sam, bowtie_unal, bowtie_log ]
         linkMerge: merge_flattened
+        pickValue: all_non_null
       dir_name: bowtie_name
     out: [ subdir ]
 
@@ -100,6 +103,7 @@ steps:
         source: [ counter_features, counter_other, counter_alignment_stats, counter_summary_stats,
                   counter_intermed, counter_aln_diag, counter_selection_diag, features_csv ]
         linkMerge: merge_flattened
+        pickValue: all_non_null
       dir_name: counter_name
     out: [ subdir ]
 
@@ -110,6 +114,7 @@ steps:
       dir_files:
         source: [ dge_norm, dge_comparisons, dge_pca ]
         linkMerge: merge_flattened
+        pickValue: all_non_null
       dir_name: dge_name
     out: [ subdir ]
 
@@ -120,6 +125,7 @@ steps:
       dir_files:
         source: [ plotter_plots ]
         linkMerge: merge_flattened
+        pickValue: all_non_null
       dir_name: plotter_name
     out: [ subdir ]
 

--- a/aquatx/extras/run_config_template.yml
+++ b/aquatx/extras/run_config_template.yml
@@ -248,7 +248,7 @@ plot_requests:
   - 'replicate_scatter'
   - 'sample_avg_scatter'
   - 'sample_avg_scatter_by_class'
-  - 'sample_avg_scatter_by_deg'
+  - 'sample_avg_scatter_by_dge'
   - 'sample_avg_scatter_by_both'
 
 ##-- You may supply your own matplotlib style sheet to override defaults here --##

--- a/aquatx/extras/run_config_template.yml
+++ b/aquatx/extras/run_config_template.yml
@@ -36,8 +36,8 @@ run_bowtie_build: True
 ##-- For best performance, this should be equal to your computer's processor core count --##
 threads: 4
 
-##-- If True: cwltool will print detailed workflow operation details --##
-debug: False
+##-- Control the amount of information printed to terminal: debug, normal, quiet --##
+verbosity: normal
 
 ##-- (EXPERIMENTAL) If True: process each sample library in parallel --##
 run_parallel: False

--- a/aquatx/srna/aquatx-deseq.r
+++ b/aquatx/srna/aquatx-deseq.r
@@ -65,14 +65,14 @@ classes <- data.frame(counts[2])
 counts <- data.frame(sapply(counts[3:length(counts)], as.integer), row.names = rownames(counts))
 # Create a data frame matching the file, name, condition
 samples <- colnames(counts)
-condition <- rep('none', length(samples))
+sampleCondition <- rep('none', length(samples))
 for (i in 1:length(samples)){
   sample <- as.character(samples[i])
-  condition[i] <- strsplit(sample, '_rep_')[[1]][1]
+  sampleCondition[i] <- strsplit(sample, '_rep_')[[1]][1]
 }
 
 # Create the deseqdataset
-sample_table <- data.frame(row.names=samples, condition=condition)
+sample_table <- data.frame(row.names=samples, condition=factor(sampleCondition))
 deseq_ds <- DESeqDataSetFromMatrix(countData = counts, colData = sample_table, design = ~ condition)
 
 #### ---- Run DESeq2 & write outputs ---- ####
@@ -85,7 +85,7 @@ deseq_counts <- df_with_classes(counts(deseq_run, normalized=TRUE))
 write.csv(deseq_counts, paste(out_pref, "norm_counts.csv", sep="_"))
 
 # Create & retrieve all possible comparisons
-all_comparisons <- t(combn(unique(condition), 2))
+all_comparisons <- t(combn(unique(sampleCondition), 2))
 for (i in 1:nrow(all_comparisons)){
   comparison <- all_comparisons[i,]
 

--- a/aquatx/srna/counter/counter.py
+++ b/aquatx/srna/counter/counter.py
@@ -206,7 +206,7 @@ def map_and_reduce(libraries, work_args, ret_queue):
     return summary
 
 
-@report_execution_time("Overall runtime")
+@report_execution_time("Counter's overall runtime")
 def main():
     # Get command line arguments.
     args = get_args()

--- a/aquatx/srna/plotter.py
+++ b/aquatx/srna/plotter.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from typing import Optional, Dict, Union
 from pkg_resources import resource_filename
 
+from aquatx.srna.Configuration import timestamp_format
 from aquatx.srna.plotterlib import plotterlib as lib
 from aquatx.srna.util import report_execution_time
 
@@ -95,11 +96,11 @@ def len_dist_plots(files_list: list, out_prefix:str, **kwargs):
 
         # Parse the "sample_rep_N" string from the input filename to avoid duplicate out_prefix's in the basename
         basename = os.path.splitext(os.path.basename(size_file))[0]
-        date_prefix_pos = re.search(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_", basename).span()
+        date_prefix_pos = re.search(timestamp_format, basename).span()
 
         if date_prefix_pos is not None:
             # File is a pipeline product
-            begin = date_prefix_pos[1]
+            begin = date_prefix_pos[1] + 1
             end = basename.rfind("_nt_len_dist")
             condition_and_rep = basename[begin:end]
         else:
@@ -215,7 +216,7 @@ def load_dge_tables(comparisons: list) -> pd.DataFrame:
     return de_table
 
 
-def scatter_samples(count_df, output_prefix, classes=None, dges=None, unknown=False, pval=0.05):
+def scatter_samples(count_df, output_prefix, classes=None, dges=None, show_unknown=False, pval=0.05):
     """Creates PDFs of all pairwise comparison scatter plots from a count table.
     Can highlight classes and/or differentially expressed genes as different colors.
 
@@ -224,14 +225,14 @@ def scatter_samples(count_df, output_prefix, classes=None, dges=None, unknown=Fa
         output_prefix: A string to use as a prefix for saving files
         classes: A dataframe containing class(es) per feature
         dges: A dataframe of differential gene table output to highlight
-        unknown: Boolean indicating if "unknown" classes should be highlighted
+        show_unknown: Boolean indicating if "unknown" classes should be highlighted
     """
     samples = get_pairs(list(count_df.columns))
 
     if (classes is not None) and (dges is not None):
         uniq_classes = list(pd.unique(classes))
         
-        if not unknown:
+        if not show_unknown and 'unknown' in uniq_classes:
             uniq_classes.remove('unknown')
         
         for pair in dges:
@@ -255,7 +256,7 @@ def scatter_samples(count_df, output_prefix, classes=None, dges=None, unknown=Fa
     elif classes is not None:
         uniq_classes = list(pd.unique(classes))
         
-        if not unknown:
+        if not show_unknown and 'unknown' in uniq_classes:
             uniq_classes.remove('unknown')
         
         grp_args = []

--- a/aquatx/srna/plotter.py
+++ b/aquatx/srna/plotter.py
@@ -461,7 +461,7 @@ def setup(args: argparse.Namespace) -> dict:
     return relevant_vars
 
 
-@report_execution_time("Main routine")
+@report_execution_time("Plotter runtime")
 def main():
     """
     Main routine

--- a/aquatx/srna/plotterlib.py
+++ b/aquatx/srna/plotterlib.py
@@ -6,16 +6,24 @@ You may override these styles by obtaining a copy of the style sheet (aquatx get
 modifying it, and passing it to aquatx-plot via the -s/--style-sheet argument. If
 using this module directly, it may be passed at construction time.
 """
-
-import itertools
-from typing import Union
-
-import numpy as np
 import pandas as pd
+import numpy as np
+import itertools
+import locale
+import os
+
+# cwltool appears to unset all environment variables including those related to locale
+# This leads to warnings from plt's FontConfig manager, but only for pipeline/cwl runs
+curr_locale = locale.getlocale()
+if curr_locale[0] is None:
+    # Default locale otherwise unset
+    os.environ['LC_CTYPE'] = 'en_US.UTF-8'
+
 import matplotlib as mpl
 import matplotlib.ticker as tix
 import matplotlib.pyplot as plt
-import warnings; warnings.filterwarnings(action='once')
+
+from typing import Union
 
 
 class plotterlib:
@@ -87,7 +95,7 @@ class plotterlib:
         class_prop = class_s / class_s.sum()
 
         # Create the plot
-        cpie = class_prop.plot(kind='pie', **kwargs)
+        cpie = class_prop.plot(kind='pie', normalize=True, **kwargs)
         cpie.legend(loc='best', bbox_to_anchor=(1, 0.5), fontsize=10, labels=class_prop.index)
         cpie.set_aspect("equal")
         cpie.set_ylabel('')
@@ -156,15 +164,16 @@ class plotterlib:
             lim_min: The minimum value to set axis limits
             lim_max: The maximum value to set axis limits
         """
-        if np.min(np.min(df)) == -np.inf:
+
+        if np.min(df) == -np.inf:
             df_min = 0
         else:
-            df_min = np.min(np.min(df))
+            df_min = np.min(df)
 
-        if np.max(np.max(df)) == np.inf:
-            df_max = np.max(np.max(df[~(df == np.inf)]))
+        if np.max(df) == np.inf:
+            df_max = np.max(df[~(df == np.inf)])
         else:
-            df_max = np.max(np.max(df))
+            df_max = np.max(df)
 
         intv = (df_max - df_min) / 12
 
@@ -173,7 +182,7 @@ class plotterlib:
 
         return lim_min, lim_max
 
-    def scatter_simple(self, count_x: pd.DataFrame, count_y: pd.DataFrame, log_norm=False, **kwargs) -> plt.Axes:
+    def scatter_simple(self, count_x: pd.DataFrame, count_y: pd.DataFrame, log_norm=False, lim=None, **kwargs) -> plt.Axes:
         """Creates a simple scatter plot of counts.
 
         Args:
@@ -193,9 +202,11 @@ class plotterlib:
         if log_norm:
             count_x = count_x.apply(np.log2)
             count_y = count_y.apply(np.log2)
-            sscat_lims = self.scatter_range(pd.concat([count_x, count_y]))
-            ax.set_xlim(sscat_lims)
-            ax.set_ylim(sscat_lims)
+            # Shouldn't this be done for the entire plotted dataset and not for the initial omitted subset?
+            sscat_lims = lim if lim is not None else self.scatter_range(pd.concat([count_x, count_y]))
+            if not np.isnan(sscat_lims).any():
+                ax.set_xlim(sscat_lims)
+                ax.set_ylim(sscat_lims)
             ax.scatter(count_x, count_y, **kwargs)
 
             oldticks = ax.get_xticks()
@@ -237,13 +248,9 @@ class plotterlib:
             gscat: A scatter plot containing groups highlighted with different colors
         """
 
-        # Subset the base points to avoid overplotting
+        # Subset counts not in *args (for example, points with p-val above threshold)
         count_x_base = count_x.drop(list(itertools.chain(*args)))
         count_y_base = count_y.drop(list(itertools.chain(*args)))
-
-        # Create a base plot using counts not in *args
-        colors = iter(kwargs.get('colors', plt.rcParams['axes.prop_cycle'].by_key()['color']))
-        gscat = self.scatter_simple(count_x_base, count_y_base, log_norm=log_norm, color='#888888', marker='s', alpha=0.3, s=50, edgecolors='none', **kwargs)
 
         if log_norm:
             count_x = count_x.apply(np.log2).replace(-np.inf, 0)
@@ -252,9 +259,23 @@ class plotterlib:
         if labels is None:
             labels = list(range(len(args)))
 
+        colors = iter(kwargs.get('colors', plt.rcParams['axes.prop_cycle'].by_key()['color']))
+        ax_lim = self.scatter_range(pd.concat([count_x, count_y]))
+        argsit = iter(args)
+
+        if any([len(base_axis) == 0 for base_axis in [count_x_base, count_y_base]]):
+            group = next(argsit)
+            gscat = self.scatter_simple(count_x.loc[group], count_y.loc[group], log_norm=log_norm, color=next(colors),
+                                        marker='.', alpha=0.3, s=50, edgecolors='none', lim=ax_lim, **kwargs)
+        else:
+            # Create a base plot using counts not in *args
+            gscat = self.scatter_simple(count_x_base, count_y_base, log_norm=log_norm, color='#888888', marker='.',
+                                        alpha=0.3, s=50, edgecolors='none', lim=ax_lim, **kwargs)
+
         # Add points for each *args
-        for group in args:
-            gscat.scatter(count_x.loc[group], count_y.loc[group], color=next(colors), marker='s', alpha=0.9, s=50, edgecolors='none', **kwargs)
+        for group in argsit:
+            gscat.scatter(count_x.loc[group], count_y.loc[group], color=next(colors), marker='.',
+                          alpha=0.9, s=50, edgecolors='none', **kwargs)
 
         gscat.legend(labels=labels)
 

--- a/aquatx/srna/resume.py
+++ b/aquatx/srna/resume.py
@@ -167,7 +167,7 @@ class ResumePlotterConfig(ResumeConfig):
         inputs = {
             'raw_counts': {'var': "resume_raw", 'type': "File"},
             'norm_counts': {'var': "resume_norm", 'type': "File"},
-            'deg_tables': {'var': "resume_deg", 'type': "File[]"},
+            'dge_tables': {'var': "resume_dge", 'type': "File[]"},
             'len_dist': {'var': "resume_len_dist", 'type': "File[]"}
         }
 
@@ -189,6 +189,6 @@ class ResumePlotterConfig(ResumeConfig):
             self['resume_raw'] = self.cwl_file(glob(counter + "/*_feature_counts.csv")[0])
             self['resume_norm'] = self.cwl_file(glob(dge + "/*_norm_counts.csv")[0])
             self['resume_len_dist'] = list(map(self.cwl_file, glob(counter + "/*_nt_len_dist.csv")))
-            self['resume_deg'] = list(map(self.cwl_file, glob(dge + "/*_deseq_table.csv")))
+            self['resume_dge'] = list(map(self.cwl_file, glob(dge + "/*_deseq_table.csv")))
         except (FileNotFoundError, IndexError) as e:
             sys.exit("The following pipeline output could not be found:\n%s" % (e.filename,))

--- a/aquatx/srna/resume.py
+++ b/aquatx/srna/resume.py
@@ -86,6 +86,7 @@ class ResumeConfig(ConfigBase, ABC):
         # Load the organize-outputs subworkflow so that we may copy relevant steps
         with open(resource_filename('aquatx', 'cwl/workflows/organize-outputs.cwl')) as f:
             organizer_sub_wf = self.yaml.load(f)
+            self.workflow['requirements'].extend(organizer_sub_wf['requirements'])
 
         for step in self.steps:
             # Copy relevant steps from organize-outputs.cwl
@@ -95,11 +96,7 @@ class ResumeConfig(ConfigBase, ABC):
 
             # Update WorkflowStepInputs
             context['in']['dir_name'] = f'dir_name_{step}'
-            context['in']['dir_files'] = {
-                'source': [f"{step}/{output}" for output in wf_steps[step]['out']],
-                'pickValue': 'all_non_null',
-                'linkMerge': 'merge_flattened'
-            }
+            context['in']['dir_files']['source'] = [f"{step}/{output}" for output in wf_steps[step]['out']]
 
             # Update WorkflowOutputParameter
             wf_outputs[f'{step}_out_dir'] = {

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -26,7 +26,7 @@ paths_config: ./paths.yml
 
 ##-- The label for final outputs --##
 ##-- If none provided, the default of user_aquatx will be used --##
-run_name: my_first_run
+run_name: unit_tests
 
 ##-- If True: run bowtie-build before analyzing libraries --##
 ##-- NOTE: this option may be ignored depending on your Paths file. See Paths file. --##
@@ -36,8 +36,8 @@ run_bowtie_build: True
 ##-- For best performance, this should be equal to your computer's processor core count --##
 threads: 4
 
-##-- If True: cwltool will print detailed workflow operation details --##
-debug: False
+##-- Control the amount of information printed to terminal: debug, normal, quiet --##
+verbosity: normal
 
 ##-- (EXPERIMENTAL) If True: process each sample library in parallel --##
 run_parallel: False

--- a/tests/testdata/run_config_template.yml
+++ b/tests/testdata/run_config_template.yml
@@ -248,7 +248,7 @@ plot_requests:
   - 'replicate_scatter'
   - 'sample_avg_scatter'
   - 'sample_avg_scatter_by_class'
-  - 'sample_avg_scatter_by_deg'
+  - 'sample_avg_scatter_by_dge'
   - 'sample_avg_scatter_by_both'
 
 ##-- You may supply your own matplotlib style sheet to override defaults here --##


### PR DESCRIPTION
The following terminal warnings/errors have been addressed:
- Characters in DESeq2's design formula
- CWL workflow validation warnings
- UTF-8 locale warnings in Plotter
- Normalization warnings for pie charts in Plotter

The following improvements were made to the pipeline:
- Verbosity preference can now be set in the Run Config. We now have options for `quiet` (no cwltool output, only output from the individual steps), `normal` (the current non-debug output level), and `debug` (detailed information about cwltool operations)
- End-to-end runtime is reported; runtimes reported by steps now have clearer verbiage
- The Paths Sheet is now updated at the end of a _successful_ pipeline run. Previously the Paths Sheet was updated at the end of a run regardless of overall success/fail status
- The process of copying subdirectory steps for Resume workflows is now more robust

The following improvements were made to Plotter:
- sample_avg_scatter_by_* plots now scale correctly for the entire dataset, not just for the initial scatter group
- Rounded points are now used instead of squares for sample_avg_scatter_by_* plots
- All uses of DEG (differentially expressed genes) have been changed to DGE (differential gene expression) to be consistent with the rest of the project

